### PR TITLE
Displaying current data when on today's date

### DIFF
--- a/Site/bc_weather_station_dashboard/website/static/JavaScript/map.js
+++ b/Site/bc_weather_station_dashboard/website/static/JavaScript/map.js
@@ -106,15 +106,19 @@ function updateData(stationCode) {
             }
         }
     });
-    // If user is on Today's date, fetch latest otherwise fetch the selected date at 12:00:00
+    // If user is on Today's date on weather.html, fetch latest otherwise fetch the selected date at 12:00:00
     var selectedDate = document.getElementById('selected_date').innerHTML;
     var dataUrl = `/station_data/?`;
-    if(selectedDate == "Today") {
+    if(window.location.pathname.endsWith("fire.html")) {
+        var dateTime = selectedDate + ' 12:00:00';
+        dataUrl += `datetime=${dateTime}&station_code=${stationCode}`;
+    } else if(selectedDate == "Today") {
         dataUrl += `latest=true&station_code=${stationCode}`;
     } else {
         var dateTime = selectedDate + ' 12:00:00';
         dataUrl += `datetime=${dateTime}&station_code=${stationCode}`;
     }
+    console.log(dataUrl);
     // Return date from date picker and fetch all of the data for the clicked station
     return fetch(dataUrl)
             .then(response => {

--- a/Site/bc_weather_station_dashboard/website/static/JavaScript/map.js
+++ b/Site/bc_weather_station_dashboard/website/static/JavaScript/map.js
@@ -263,11 +263,16 @@ function getSelectedDate() {
         var year = new Date().getFullYear();
         var month = (new Date().getMonth() + 1).toString().padStart(2, '0');
         var day = new Date().getDate().toString().padStart(2, '0');
-        datePicker = `${year}-${month}-${day}`;
+        var hour = new Date().getHours().toString().padStart(2, '0');
+        datePicker = `${year}-${month}-${day} ${hour}:00:00`;
+    } else {
+        var hour = new Date().getHours().toString().padStart(2, '0');
+        datePicker = datePicker + " " + hour + ":00:00";
+        // datePicker = datePicker + " 12:00:00";
     }
-    return datePicker + " 12:00:00";
+    console.log(datePicker);
+    return datePicker;
 }
-
 // Function to check if geolocation is available
 function checkLocation() {
     // If geolocation is available

--- a/Site/bc_weather_station_dashboard/website/static/JavaScript/map.js
+++ b/Site/bc_weather_station_dashboard/website/static/JavaScript/map.js
@@ -203,8 +203,11 @@ function updateDataHTML(currentStationData) {
         }
         // Update the HTML elements with the station's wind gust data
         if (currentStationData.HOURLY_WIND_GUST !== undefined) {
-            document.getElementById('wind-gust').innerHTML = currentStationData.HOURLY_WIND_GUST;
-        }
+            document.getElementById('wind-speed').textContent = currentStationData.HOURLY_WIND_SPEED + " km/h";
+            var windGustText = currentStationData.HOURLY_WIND_GUST + " km/h";
+            document.getElementById('wind-gust').innerHTML = windGustText;
+    
+            updateWindSpeed(currentStationData.HOURLY_WIND_SPEED, currentStationData.HOURLY_WIND_GUST);        }
         // Check if the current page is fire.html
     } else if (path.endsWith('/fire/')) {
         // Update the HTML elements with the station's fine fuel moisture code data

--- a/Site/bc_weather_station_dashboard/website/static/JavaScript/map.js
+++ b/Site/bc_weather_station_dashboard/website/static/JavaScript/map.js
@@ -106,10 +106,16 @@ function updateData(stationCode) {
             }
         }
     });
-
+    // If user is on Today's date, fetch latest otherwise fetch the selected date at 12:00:00
+    var dataUrl = undefined;
+    if(document.getElementById('selected_date').innerHTML == "Today") {
+        dataUrl = `/station_data/?latest=true`;
+    } else {
+        dataUrl = `/station_data/?datetime=` + document.getElementById('selected_date').innerHTML + " 12:00:00";
+    }
     // Return date from date picker and fetch all of the data for the clicked station
-    return fetch("/station_data/?datetime=" + getSelectedDate())
-        .then(response => {
+    return fetch(dataUrl)
+            .then(response => {
             // If station data is found
             var errorMsg = document.getElementById("error-msg");
             if (response.ok) {
@@ -256,23 +262,6 @@ function updateDataHTML(currentStationData) {
     }
 }
 
-// Function to get the selected date from the date picker
-function getSelectedDate() {
-    var datePicker = document.getElementById('selected_date').innerHTML;
-    if (datePicker === "Today") {
-        var year = new Date().getFullYear();
-        var month = (new Date().getMonth() + 1).toString().padStart(2, '0');
-        var day = new Date().getDate().toString().padStart(2, '0');
-        var hour = new Date().getHours().toString().padStart(2, '0');
-        datePicker = `${year}-${month}-${day} ${hour}:00:00`;
-    } else {
-        var hour = new Date().getHours().toString().padStart(2, '0');
-        datePicker = datePicker + " " + hour + ":00:00";
-        // datePicker = datePicker + " 12:00:00";
-    }
-    console.log(datePicker);
-    return datePicker;
-}
 // Function to check if geolocation is available
 function checkLocation() {
     // If geolocation is available
@@ -407,7 +396,6 @@ module.exports = {
     initMap,
     initMarkerIcon,
     updateDataHTML,
-    getSelectedDate,
     checkLocation,
     computeDistance
 };

--- a/Site/bc_weather_station_dashboard/website/static/JavaScript/map.js
+++ b/Site/bc_weather_station_dashboard/website/static/JavaScript/map.js
@@ -107,11 +107,13 @@ function updateData(stationCode) {
         }
     });
     // If user is on Today's date, fetch latest otherwise fetch the selected date at 12:00:00
-    var dataUrl = undefined;
-    if(document.getElementById('selected_date').innerHTML == "Today") {
-        dataUrl = `/station_data/?latest=true`;
+    var selectedDate = document.getElementById('selected_date').innerHTML;
+    var dataUrl = `/station_data/?`;
+    if(selectedDate == "Today") {
+        dataUrl += `latest=true&station_code=${stationCode}`;
     } else {
-        dataUrl = `/station_data/?datetime=` + document.getElementById('selected_date').innerHTML + " 12:00:00";
+        var dateTime = selectedDate + ' 12:00:00';
+        dataUrl += `datetime=${dateTime}&station_code=${stationCode}`;
     }
     // Return date from date picker and fetch all of the data for the clicked station
     return fetch(dataUrl)

--- a/Site/bc_weather_station_dashboard/website/static/JavaScript/map.js
+++ b/Site/bc_weather_station_dashboard/website/static/JavaScript/map.js
@@ -136,7 +136,7 @@ function updateData(stationCode) {
                 return response.json();
                 // If station data for this datetime is not found/error occurs
             } else {
-                errorMsg.innerHTML = "There is no data found for this station on " + getSelectedDate() + ". Please select another date."
+                errorMsg.innerHTML = "There is no data found for this station on this date. Please select another date."
                 errorMsg.style.display = "block";
                 throw new Error("There is no station data for this date or this station is missing some of its' data. Error code " + response.status + ".");
             }

--- a/Site/bc_weather_station_dashboard/website/static/JavaScript/map.js
+++ b/Site/bc_weather_station_dashboard/website/static/JavaScript/map.js
@@ -109,11 +109,17 @@ function updateData(stationCode) {
     // If user is on Today's date on weather.html, fetch latest otherwise fetch the selected date at 12:00:00
     var selectedDate = document.getElementById('selected_date').innerHTML;
     var dataUrl = `/station_data/?`;
-    if(window.location.pathname.endsWith("fire.html")) {
-        var dateTime = selectedDate + ' 12:00:00';
-        dataUrl += `datetime=${dateTime}&station_code=${stationCode}`;
-    } else if(selectedDate == "Today") {
-        dataUrl += `latest=true&station_code=${stationCode}`;
+    if(selectedDate == "Today") {
+        if(window.location.pathname.endsWith("fire/")) {
+            var today = new Date();
+            var year = today.getFullYear();
+            var month = String(today.getMonth() + 1).padStart(2, '0');
+            var day = String(today.getDate()).padStart(2, '0');
+            var dateTime = `${year}-${month}-${day} 12:00:00`;
+            dataUrl += `datetime=${dateTime}&station_code=${stationCode}`;
+        } else {
+            dataUrl += `latest=true&station_code=${stationCode}`;
+        }
     } else {
         var dateTime = selectedDate + ' 12:00:00';
         dataUrl += `datetime=${dateTime}&station_code=${stationCode}`;
@@ -222,50 +228,6 @@ function updateDataHTML(currentStationData) {
         // Update the HTML elements with the station's danger rating data
         updateDangerRating(currentStationData.DANGER_RATING);
     }
-    if (currentStationData.HOURLY_TEMPERATURE) {
-        document.getElementById('temperature').innerHTML = currentStationData.HOURLY_TEMPERATURE;
-    }
-    // Update the HTML elements with the station's relative humidity data
-    if (currentStationData.HOURLY_RELATIVE_HUMIDITY != null) {
-        // Get the relative humidity
-        var relativeHumidity = currentStationData.HOURLY_RELATIVE_HUMIDITY;
-        // Get the progress bar element
-        const progressBarElement = document.querySelector('#humidity-progress-bar');
-        // Create a new SemiCircleProgressBar with the progress bar element
-        const progressBar = new SemiCircleProgressBar(progressBarElement);
-        // Set the value of the progress bar to the relative humidity
-        progressBar.setValue(relativeHumidity);
-    }
-    // Update the HTML elements with the station's precipitation data
-    if (currentStationData.HOURLY_PRECIPITATION) {
-        document.getElementById('precipitation').innerHTML = currentStationData.HOURLY_PRECIPITATION + " mm";
-    }
-    // Update the HTML elements with the station's snow depth data
-    if (currentStationData.SNOW_DEPTH) {
-        document.getElementById('snow-depth').innerHTML = currentStationData.SNOW_DEPTH + " mm";
-    }
-    // Update the HTML elements with the station's snow quality data
-    if (currentStationData.SNOW_DEPTH_QUALITY) {
-        document.getElementById('snow-quality').innerHTML = currentStationData.SNOW_DEPTH_QUALITY + " mm";
-    }
-    // Update the HTML elements with the station's wind data
-    if (currentStationData.HOURLY_WIND_SPEED && currentStationData.HOURLY_WIND_GUST) {
-        document.getElementById('wind-speed').textContent = currentStationData.HOURLY_WIND_SPEED + " km/h";
-        var windGustText = currentStationData.HOURLY_WIND_GUST + " km/h";
-        document.getElementById('wind-gust').innerHTML = windGustText;
-
-        updateWindSpeed(currentStationData.HOURLY_WIND_SPEED, currentStationData.HOURLY_WIND_GUST);
-    }
-    // Update the HTML elements with the station's wind direction data
-    if (currentStationData.HOURLY_WIND_DIRECTION) {
-        // Get the wind direction in degrees
-        var windDirectionDegrees = currentStationData.HOURLY_WIND_DIRECTION;
-        // Update the text display append to the wind direction widget
-        document.getElementById('wind-direction').innerHTML = "<h5>Wind Direction " + windDirectionDegrees + "&deg;</h5>";
-        // Create a new WindArrow with the updated wind direction
-        var windArrow = new WindArrow(windDirectionDegrees);
-        windArrow.draw();
-    }
 }
 
 // Function to check if geolocation is available
@@ -358,15 +320,6 @@ function computeDistance(longitude1, latitude1, longitude2, latitude2) {
 var eventListeners = document.addEventListener('DOMContentLoaded', function () {
     // Add event listener for change of selection of date picker, resets values of widgets to N/A before updating them so old values don't linger
     document.getElementById('date_selector').addEventListener('change', function () {
-        // Reset all elements here since an error caused by null value may not allow the request to make it to updateDataHTML
-        document.getElementById('temperature').innerHTML = "N/A";
-        // document.getElementById('relative-humidity').innerHTML = "N/A";
-        document.getElementById('precipitation').innerHTML = "N/A";
-        document.getElementById('snow-depth').innerHTML = "N/A";
-        document.getElementById('snow-quality').innerHTML = "N/A";
-        document.getElementById('wind-speed').innerHTML = "N/A";
-        document.getElementById('wind-direction').innerHTML = "N/A";
-        document.getElementById('wind-gust').innerHTML = "N/A";
         // Update all data since date time is changing
         updateData(currentStationCode);
     });

--- a/Site/bc_weather_station_dashboard/website/templates/fire.html
+++ b/Site/bc_weather_station_dashboard/website/templates/fire.html
@@ -36,7 +36,7 @@
     <div class="container-fluid">
         <div class="row pt-3">
             <!-- Station Map Column -->
-            <div class="col-md-4 col-sm-12 text-center border-right">
+            <div class="col-md-4 col-sm-12 text-center border-right border-dark">
                 <h2 id="station-name-code"></h2>
                 <hr>
                 <!-- Leaflet Map Implementation -->

--- a/Site/bc_weather_station_dashboard/website/templates/fire.html
+++ b/Site/bc_weather_station_dashboard/website/templates/fire.html
@@ -60,7 +60,9 @@
             </div>
             <!-- Fire Information Column -->
             <div class="col-md-8">
-                <h2>Fire Information</h2>
+                <h2 class="foreground text-center">
+                    Fire Information
+                </h2>
                 <hr>
                 <div class="container">
                     <div class="row">

--- a/Site/bc_weather_station_dashboard/website/templates/fire.html
+++ b/Site/bc_weather_station_dashboard/website/templates/fire.html
@@ -40,7 +40,9 @@
                 <h2 id="station-name-code"></h2>
                 <hr>
                 <!-- Leaflet Map Implementation -->
-                <div id="map" style="height: 50em; width: 100%;"></div>
+                <div id="map" style="height: 50em; width: 100%;">
+                    <button id="find-me-btn">Find me!</button>
+                </div>
                 <script src="{% static 'JavaScript/map.js' %}"></script>
                 <!-- Search bar -->
                 <div class="container mt-4">

--- a/Site/bc_weather_station_dashboard/website/tests/abi/map.test.js
+++ b/Site/bc_weather_station_dashboard/website/tests/abi/map.test.js
@@ -13,7 +13,7 @@ global.L = {
 // Create variables for fetch mocking and functions, and jsdom
 const fetchMock = require('jest-fetch-mock');
 fetchMock.enableMocks();
-const { initMap, initMarkerIcon, computeDistance, updateDataHTML, getSelectedDate, checkLocation } = require('../../static/JavaScript/map');
+const { initMap, initMarkerIcon, computeDistance, updateDataHTML, checkLocation } = require('../../static/JavaScript/map');
 require('@testing-library/jest-dom');
 
 // Define a test suite for the initialization of leaflet map and markers
@@ -148,28 +148,6 @@ describe('computeDistance() Functionality', () => {
     test('Correctly computes distance between two of the same points.', () => {
         const distance = computeDistance(0, 0, 0, 0);
         expect(distance).toBeCloseTo(0, 0);
-    });
-});
-
-// Define a test suite for the getSelectedDate() function
-describe('getSelectedDate() Functionality', () => {
-    // Create dom element before each test
-    beforeAll(() => {
-        document.body.innerHTML = `<div id="selected_date"></div>`;
-    });
-    // Create a test for getting the datetime when date picker is set to Today
-    test('Correctly returns the current date and time when date picker is set to "Today".', () => {
-        document.getElementById('selected_date').innerHTML = "Today";
-        const fixedDate = new Date('2024-03-19T12:00:00Z');
-        jest.useFakeTimers().setSystemTime(fixedDate);
-        expect(getSelectedDate()).toBe('2024-03-19 12:00:00');
-        jest.useRealTimers();
-    });
-    // Create a test for getting the datetime when date picker is set to a specific date
-    test('Correctly returns the current date and time when date picker is set to a specific date.', () => {
-        const specificDate = '2024-03-19';
-        document.getElementById('selected_date').innerHTML = specificDate;
-        expect(getSelectedDate()).toBe(specificDate + ' 12:00:00');
     });
 });
 

--- a/Site/bc_weather_station_dashboard/website/views.py
+++ b/Site/bc_weather_station_dashboard/website/views.py
@@ -14,6 +14,7 @@ from twilio.rest import Client
 from django.conf import settings
 from .models import UserProfile
 from .forms import UserProfileForm
+from django.db.models import Max
 
 
 current_page = "weather"
@@ -194,28 +195,34 @@ def update_feedback_status(request):
 
 
 def station_data(request):
-    # Get the selected date from the query
-    selected_date = request.GET.get("datetime", None)
-    # Check if date is undefined
-    if selected_date == "undefined":
-        return JsonResponse(
-            {"error": "No data found for the specified date and time"}, status=404
-        )
-    # Filter the station data to only retrieve data from specified date
-    data = StationData.objects.filter(DATE_TIME=selected_date)
-    # Check if the data is empty
+    # Check if the request is for the latest data
+    latest = request.GET.get("latest", "false").lower() == "true"
+
+    # Handle request for the latest data
+    if latest:
+        latest_entry = StationData.objects.aggregate(latest_date=Max('DATE_TIME'))['latest_date']
+        if latest_entry is None:
+            return JsonResponse({"error": "No data available"}, status=404)
+        data = StationData.objects.filter(DATE_TIME=latest_entry)
+    
+    else:
+        # Get the selected date from the query
+        selected_date = request.GET.get("datetime", None)
+        if selected_date is None or selected_date == "undefined":
+            return JsonResponse({"error": "No data found for the specified date and time"}, status=404)
+        
+        # Filter the station data to only retrieve data from the specified date
+        data = StationData.objects.filter(DATE_TIME=selected_date)
+
     if not data.exists():
-        # Return an empty JSON response of an error message indicating no data was found
-        return JsonResponse(
-            {"error": "No data found for the specified date and time"}, status=404
-        )
+        return JsonResponse({"error": "No data found"}, status=404)
     # Create dictionary of data
     measures = [
         {
             "created_at_timestamp": measure.created_at_timestamp,
             "STATION_CODE": measure.STATION_CODE,
             "STATION_NAME": measure.STATION_NAME,
-            "DATE_TIME": measure.DATE_TIME,
+            "DATE_TIME": measure.DATE_TIME.strftime("%Y-%m-%d %H:%M:%S"),
             "HOURLY_PRECIPITATION": measure.HOURLY_PRECIPITATION,
             "HOURLY_TEMPERATURE": measure.HOURLY_TEMPERATURE,
             "HOURLY_RELATIVE_HUMIDITY": measure.HOURLY_RELATIVE_HUMIDITY,


### PR DESCRIPTION
## In this PR:

- Changed the django view for station data to either show the latest data or show the data for a selected date. This change made the dashboard slow  quite slow in displaying data so I also changed the view to filter for station data as well, this made a huge difference in time taken to show the data once a station/date was clicked and the speed is as quick as it was before.

- Basically, when the user is on "Today", the dashboard displays the most recent data. When the user selects a date that is not "Today", the dashboard shows the data for that day at 12pm.

- Also added implementation of find me button on fire page.

Closes #157 #213 