### PR TITLE
154 date switching bug

### DIFF
--- a/Site/bc_weather_station_dashboard/website/static/JavaScript/map.js
+++ b/Site/bc_weather_station_dashboard/website/static/JavaScript/map.js
@@ -39,6 +39,10 @@ function initMarkerIcon(markerIcon) {
     return markerIcon;
 }
 
+window.onload = function() {
+    fetchWeatherStationInfo();
+};
+
 // Create function to fetch weather station information
 function fetchWeatherStationInfo() {
     return fetch('/weather_stations_information/')
@@ -62,12 +66,21 @@ function fetchWeatherStationInfo() {
                 let selectedStation = data.find(s => s.id === station.id);
                 if (selectedStation) {
                     createMarker(selectedStation, 1);
-                    // Call updateData with the correct station code
-                    updateData(selectedStation.code);
                 }
             } else {
                 // If there isn't, get user location
                 checkLocation();
+            }
+            // Retrieve date from localStorage
+            var storedDate = localStorage.getItem('selectedDate');
+
+            // If date is stored, update the date picker
+            if (storedDate) {
+                // Set the selected date in the date picker
+                const date = new Date(storedDate);
+                const dateString = date.toISOString().split('T')[0]; // Convert the date to yyyy-mm-dd format
+                document.getElementById('datepicker').value = dateString;
+                document.getElementById('selected_date').innerHTML = storedDate;
             }
             // Create marker for each weather station
             data.forEach(station => {
@@ -81,37 +94,6 @@ function fetchWeatherStationInfo() {
             return undefined;
         });
 }
-
-window.onload = function() {
-    // Retrieve station and date from localStorage
-    var storedStationCode = localStorage.getItem('currentStationCode');
-    var storedDate = localStorage.getItem('selectedDate');
-
-    // If station and date are stored, update the data
-    if (storedStationCode && storedDate) {
-        updateData(storedStationCode);
-        // Set the selected date in the date picker
-        const date = new Date(storedDate);
-        const dateString = date.toISOString().split('T')[0]; // Convert the date to yyyy-mm-dd format
-        document.getElementById('datepicker').value = dateString;
-        document.getElementById('selected_date').innerHTML = storedDate;
-    }
-};
-
-document.addEventListener('DOMContentLoaded', (event) => {
-    const date_input = document.getElementById('datepicker');
-    if (date_input) {
-        date_input.addEventListener('change', function (e) {
-            // Retrieve the stored station code
-            var storedStationCode = localStorage.getItem('currentStationCode');
-
-            // Call updateData with the stored station code and the selected date
-            if (storedStationCode) {
-                updateData(storedStationCode);
-            }
-        });
-    }
-});
 
 // Function to update the data on the right column
 function updateData(stationCode) {
@@ -177,6 +159,7 @@ function updateData(stationCode) {
                 // Set current station data to station with stationCode
                 var currentStationData = stationData.find(measure => measure.STATION_CODE === stationCode);
                 updateDataHTML(currentStationData);
+                console.log("updatehtml" + currentStationData);
             }
         })
         .catch(error => {

--- a/Site/bc_weather_station_dashboard/website/static/JavaScript/map.js
+++ b/Site/bc_weather_station_dashboard/website/static/JavaScript/map.js
@@ -174,9 +174,6 @@ function updateData(stationCode) {
 
 // Update HTML elements on right side
 function updateDataHTML(currentStationData) {
-
-    console.log(currentStationData);
-    console.log(window.location.pathname);
     // Get the current page's path
     var path = window.location.pathname;
 
@@ -358,14 +355,27 @@ var eventListeners = document.addEventListener('DOMContentLoaded', function () {
     // Add event listener for change of selection of date picker, resets values of widgets to N/A before updating them so old values don't linger
     document.getElementById('date_selector').addEventListener('change', function () {
         // Reset all elements here since an error caused by null value may not allow the request to make it to updateDataHTML
-        document.getElementById('temperature').innerHTML = "N/A";
-        // document.getElementById('relative-humidity').innerHTML = "N/A";
-        document.getElementById('precipitation').innerHTML = "N/A";
-        document.getElementById('snow-depth').innerHTML = "N/A";
-        document.getElementById('snow-quality').innerHTML = "N/A";
-        document.getElementById('wind-speed').innerHTML = "N/A";
-        document.getElementById('wind-direction').innerHTML = "N/A";
-        document.getElementById('wind-gust').innerHTML = "N/A";
+        if (document.getElementById('temperature')) {
+            document.getElementById('temperature').innerHTML = "N/A";
+        }
+        if (document.getElementById('precipitation')) {
+            document.getElementById('precipitation').innerHTML = "N/A";
+        }
+        if (document.getElementById('snow-depth')) {
+            document.getElementById('snow-depth').innerHTML = "N/A";
+        }
+        if (document.getElementById('snow-quality')) {
+            document.getElementById('snow-quality').innerHTML = "N/A";
+        }
+        if (document.getElementById('wind-speed')) {
+            document.getElementById('wind-speed').innerHTML = "N/A";
+        }
+        if (document.getElementById('wind-direction')) {
+            document.getElementById('wind-direction').innerHTML = "N/A";
+        }
+        if (document.getElementById('wind-gust')) {
+            document.getElementById('wind-gust').innerHTML = "N/A";
+        }
         // Update all data since date time is changing
         updateData(currentStationCode);
     });

--- a/Site/bc_weather_station_dashboard/website/static/JavaScript/map.js
+++ b/Site/bc_weather_station_dashboard/website/static/JavaScript/map.js
@@ -91,23 +91,23 @@ window.onload = function() {
     if (storedStationCode && storedDate) {
         updateData(storedStationCode);
         // Set the selected date in the date picker
+        const date = new Date(storedDate);
+        const dateString = date.toISOString().split('T')[0]; // Convert the date to yyyy-mm-dd format
+        document.getElementById('datepicker').value = dateString;
         document.getElementById('selected_date').innerHTML = storedDate;
     }
 };
 
 document.addEventListener('DOMContentLoaded', (event) => {
-    const date_input = document.querySelector('.datepicker-input');
+    const date_input = document.getElementById('datepicker');
     if (date_input) {
         date_input.addEventListener('change', function (e) {
-            // Get the selected date
-            const selected_date = getSelectedDate();
-
             // Retrieve the stored station code
             var storedStationCode = localStorage.getItem('currentStationCode');
 
             // Call updateData with the stored station code and the selected date
             if (storedStationCode) {
-                updateData(storedStationCode, selected_date);
+                updateData(storedStationCode);
             }
         });
     }

--- a/Site/bc_weather_station_dashboard/website/templates/fire.html
+++ b/Site/bc_weather_station_dashboard/website/templates/fire.html
@@ -49,7 +49,9 @@
                     {% endif %}
                 </div>
                 <!-- Leaflet Map Implementation -->
-                <div id="map" style="height: 50em; width: 100%;"></div>
+                <div id="map" style="height: 60em; width: 100%;">
+                    <button id="find-me-btn">Find me!</button>
+                </div>
                 <script src="{% static 'JavaScript/map.js' %}"></script>
                 <!-- Search bar -->
                 <div class="container mt-4">

--- a/Site/bc_weather_station_dashboard/website/templates/fire.html
+++ b/Site/bc_weather_station_dashboard/website/templates/fire.html
@@ -34,11 +34,20 @@
     {% include 'navbar.html' %}
 
     <div class="container-fluid">
-        <div class="row pt-3">
+        <div class="row">
             <!-- Station Map Column -->
             <div class="col-md-4 col-sm-12 text-center border-right">
-                <h2 id="station-name-code"></h2>
-                <hr>
+                <div class="foreground d-flex justify-content-between align-items-center mb-2" style="height: 65px;">
+                    <div class="align-self-center pt-2">
+                        <h4 id="station-name-code" class="foreground"></h4>
+                    </div>
+                    {% if request.user.is_authenticated %}
+
+                    <button type="button" class="btn btn-success favourite-button" style="margin-left: 1em;"
+                        id="favourite-button">Favourite</button>
+
+                    {% endif %}
+                </div>
                 <!-- Leaflet Map Implementation -->
                 <div id="map" style="height: 50em; width: 100%;"></div>
                 <script src="{% static 'JavaScript/map.js' %}"></script>
@@ -58,8 +67,14 @@
             </div>
             <!-- Fire Information Column -->
             <div class="col-md-8">
-                <h2>Fire Information</h2>
-                <hr>
+                <div class="foreground d-flex justify-content-between align-items-center" style="height: 65px;">
+                    <div class="align-self-center pl-3 pt-2">
+                        <h3>Fire Information</h3>
+                    </div>
+                    <div>
+                        <button id="tomorrow-forecast" class="btn btn-warning">Tomorrow's Forecast</button>
+                    </div>
+                </div>
                 <div class="container">
                     <div class="row">
                         <!-- Column 1 -->

--- a/Site/bc_weather_station_dashboard/website/templates/fire.html
+++ b/Site/bc_weather_station_dashboard/website/templates/fire.html
@@ -280,6 +280,43 @@
         {% endif %}
     </script>
     <script>
+        $(document).ready(function () {
+            $('.favourite-button').click(function () {
+                // hide button
+                $(this).hide();
+                var stationCode = getStationCode();
+
+                $.ajax({
+                    url: "{% url 'add_to_favourites' %}",
+                    type: "POST",
+                    data: { 'station_code': stationCode },
+                    headers: { 'X-CSRFToken': getCookie('csrftoken') },
+                    success: function (data) {
+                        console.log("Successfully added to favourites");
+                    }
+                });
+            });
+        });
+
+        function getCookie(name) {
+            var cookieValue = null;
+            if (document.cookie && document.cookie !== '') {
+                var cookies = document.cookie.split(';');
+                for (var i = 0; i < cookies.length; i++) {
+                    var cookie = jQuery.trim(cookies[i]);
+                    if (cookie.substring(0, name.length + 1) === (name + '=')) {
+                        cookieValue = decodeURIComponent(cookie.substring(name.length + 1));
+                        break;
+                    }
+                }
+            }
+            return cookieValue;
+        }
+        function getStationCode() {
+            return $('#station-name-code').text().split('#')[1];
+        }
+    </script>
+    <script>
         // Set tomorrow's date when the button is clicked adn call prediction function
         document.getElementById('tomorrow-forecast').addEventListener('click', function() {
             var tomorrow = new Date();

--- a/Site/bc_weather_station_dashboard/website/templates/fire.html
+++ b/Site/bc_weather_station_dashboard/website/templates/fire.html
@@ -322,7 +322,7 @@
         // Set tomorrow's date when the button is clicked adn call prediction function
         document.getElementById('tomorrow-forecast').addEventListener('click', function() {
             var tomorrow = new Date();
-            tomorrow.setDate(tomorrow.getDate() + 1);
+            tomorrow.setDate(tomorrow.getDate());
     
             // Format the date in the format expected by the datepicker
             var formattedDate = tomorrow.toISOString().split('T')[0];

--- a/Site/bc_weather_station_dashboard/website/templates/fire.html
+++ b/Site/bc_weather_station_dashboard/website/templates/fire.html
@@ -279,6 +279,26 @@
         alert("{{error}}");
         {% endif %}
     </script>
+    <script>
+        // Set tomorrow's date when the button is clicked adn call prediction function
+        document.getElementById('tomorrow-forecast').addEventListener('click', function() {
+            var tomorrow = new Date();
+            tomorrow.setDate(tomorrow.getDate() + 1);
+    
+            // Format the date in the format expected by the datepicker
+            var formattedDate = tomorrow.toISOString().split('T')[0];
+    
+            // Set the date in the datepicker
+            const date_input = document.querySelector('.datepicker-input');
+            date_input.value = formattedDate;
+    
+            // Trigger the change event to update the displayed date
+            var event = new Event('change');
+            date_input.dispatchEvent(event);
+
+            // Call the prediction function
+        });
+    </script>
 
     <!-- JS for widgets -->
     <script src="{% static 'JavaScript/danger_rating.js' %}"></script>

--- a/Site/bc_weather_station_dashboard/website/templates/fire.html
+++ b/Site/bc_weather_station_dashboard/website/templates/fire.html
@@ -37,7 +37,7 @@
         <div class="row">
             <!-- Station Map Column -->
             <div class="col-md-4 col-sm-12 text-center border-right">
-                <div class="foreground d-flex justify-content-between align-items-center mb-2" style="height: 65px;">
+                <div class="foreground d-flex justify-content-between align-items-center mb-3" style="height: 60px;">
                     <div class="align-self-center pt-2">
                         <h4 id="station-name-code" class="foreground"></h4>
                     </div>
@@ -67,8 +67,8 @@
             </div>
             <!-- Fire Information Column -->
             <div class="col-md-8">
-                <div class="foreground d-flex justify-content-between align-items-center" style="height: 65px;">
-                    <div class="align-self-center pl-3 pt-2">
+                <div class="foreground d-flex justify-content-between align-items-center mb-1" style="height: 60px;">
+                    <div class="align-self-center pl-3 pt-1">
                         <h3>Fire Information</h3>
                     </div>
                     <div>

--- a/Site/bc_weather_station_dashboard/website/templates/navbar.html
+++ b/Site/bc_weather_station_dashboard/website/templates/navbar.html
@@ -7,10 +7,10 @@
     <div id="date_selector" class="ml-auto">
         <strong><span id="selected_date" class="text-white p-2">Today</span></strong>
         <img class="datepicker-toggle-button" src="../static/images/calendar_icon.svg" alt="calendar icon" width="30">
-        <input type="date" class="datepicker-input">
+        <input type="date" class="datepicker-input" id="datepicker">
     </div>
     <script>
-        const date_input = document.querySelector('.datepicker-input');
+        const date_input = document.querySelector('#datepicker');
         const selected_date = document.querySelector('#selected_date');
         date_input.addEventListener('change', function (e) {
             const date = new Date(e.target.value);

--- a/Site/bc_weather_station_dashboard/website/templates/navbar.html
+++ b/Site/bc_weather_station_dashboard/website/templates/navbar.html
@@ -93,3 +93,4 @@
         </div>
     </div>
 </div>
+<script src="{% static 'js/map.js' %}"></script>

--- a/Site/bc_weather_station_dashboard/website/templates/navbar.html
+++ b/Site/bc_weather_station_dashboard/website/templates/navbar.html
@@ -9,14 +9,20 @@
         <img class="datepicker-toggle-button" src="../static/images/calendar_icon.svg" alt="calendar icon" width="30">
         <input type="date" class="datepicker-input">
     </div>
-    <script> // should be moved to a separate file when we make one
+    <script>
         const date_input = document.querySelector('.datepicker-input');
         const selected_date = document.querySelector('#selected_date');
         date_input.addEventListener('change', function (e) {
             const date = new Date(e.target.value);
             const adjusted_date = new Date(date.getTime() + date.getTimezoneOffset() * 60 * 1000);
-            if (adjusted_date.toDateString() === new Date().toDateString()) {
+            const today = new Date();
+            const tomorrow = new Date(today);
+            tomorrow.setDate(tomorrow.getDate() + 1);
+    
+            if (adjusted_date.toDateString() === today.toDateString()) {
                 selected_date.textContent = "Today";
+            } else if (adjusted_date.toDateString() === tomorrow.toDateString()) {
+                selected_date.textContent = "Tomorrow";
             } else {
                 selected_date.textContent = adjusted_date.toLocaleDateString('en-CA');
             }

--- a/Site/bc_weather_station_dashboard/website/templates/weather.html
+++ b/Site/bc_weather_station_dashboard/website/templates/weather.html
@@ -289,7 +289,7 @@
         }
     </script>
     <script>
-        // Set tomorrow's date when the button is clicked
+        // Set tomorrow's date when the button is clicked adn call prediction function
         document.getElementById('tomorrow-forecast').addEventListener('click', function() {
             var tomorrow = new Date();
             tomorrow.setDate(tomorrow.getDate() + 1);
@@ -304,6 +304,8 @@
             // Trigger the change event to update the displayed date
             var event = new Event('change');
             date_input.dispatchEvent(event);
+
+            // Call the prediction function
         });
     </script>
 </body>

--- a/Site/bc_weather_station_dashboard/website/templates/weather.html
+++ b/Site/bc_weather_station_dashboard/website/templates/weather.html
@@ -42,10 +42,11 @@
             <!-- Station Map Column -->
             {% comment %} If you want to make map only take up 1/3 of page, use line below {% endcomment %}
             {% comment %} <div class="col-4 text-center border-right border-dark"> {% endcomment %}
-            <div class="col-6 text-center border-right border-dark">
-                <div style="display: flex; align-items: center; justify-content: center;">
-
-                    <h2 id="station-name-code" class="foreground"></h2>
+            <div class="col-md-6 col-sm-12 text-center border-right">
+                <div class="foreground d-flex justify-content-between align-items-center mb-2" style="height: 65px;">
+                    <div class="align-self-center pt-2">
+                        <h4 id="station-name-code" class="foreground"></h4>
+                    </div>
                     {% if request.user.is_authenticated %}
 
                     <button type="button" class="btn btn-success favourite-button" style="margin-left: 1em;"
@@ -76,9 +77,9 @@
             </div>
             <!-- Weather Data Column -->
             <div class="col-6 ">
-                <div class="foreground d-flex justify-content-between align-items-center">
-                    <div class="align-self-center ml-3 mt-1">
-                        <h2>Weather</h2>
+                <div class="foreground d-flex justify-content-between align-items-center" style="height: 65px;">
+                    <div class="align-self-center pl-3 pt-2">
+                        <h3>Weather</h3>
                     </div>
                     <div>
                         <button id="tomorrow-forecast" class="btn btn-warning">Tomorrow's Forecast</button>

--- a/Site/bc_weather_station_dashboard/website/templates/weather.html
+++ b/Site/bc_weather_station_dashboard/website/templates/weather.html
@@ -292,7 +292,7 @@
         // Set tomorrow's date when the button is clicked adn call prediction function
         document.getElementById('tomorrow-forecast').addEventListener('click', function() {
             var tomorrow = new Date();
-            tomorrow.setDate(tomorrow.getDate() + 1);
+            tomorrow.setDate(tomorrow.getDate());
     
             // Format the date in the format expected by the datepicker
             var formattedDate = tomorrow.toISOString().split('T')[0];

--- a/Site/bc_weather_station_dashboard/website/templates/weather.html
+++ b/Site/bc_weather_station_dashboard/website/templates/weather.html
@@ -76,9 +76,14 @@
             </div>
             <!-- Weather Data Column -->
             <div class="col-6 ">
-                <h2 class="foreground text-center">
-                    Weather
-                </h2>
+                <div class="foreground d-flex justify-content-between align-items-center">
+                    <div class="align-self-center ml-3 mt-1">
+                        <h2>Weather</h2>
+                    </div>
+                    <div>
+                        <button class="btn btn-warning">Tomorrow's Forecast</button>
+                    </div>
+                </div>
 
                 <!-- Row 1 -->
                 <div class="row pt-4 justify-content-center">

--- a/Site/bc_weather_station_dashboard/website/templates/weather.html
+++ b/Site/bc_weather_station_dashboard/website/templates/weather.html
@@ -38,7 +38,7 @@
     {% include 'navbar.html' %}
 
     <div class="container-fluid">
-        <div class="row pt-3">
+        <div class="row">
             <!-- Station Map Column -->
             {% comment %} If you want to make map only take up 1/3 of page, use line below {% endcomment %}
             {% comment %} <div class="col-4 text-center border-right border-dark"> {% endcomment %}
@@ -81,7 +81,7 @@
                         <h2>Weather</h2>
                     </div>
                     <div>
-                        <button class="btn btn-warning">Tomorrow's Forecast</button>
+                        <button id="tomorrow-forecast" class="btn btn-warning">Tomorrow's Forecast</button>
                     </div>
                 </div>
 
@@ -287,12 +287,23 @@
             return $('#station-name-code').text().split('#')[1];
         }
     </script>
-
-
-
-    <!-- JS for widgets -->
-    <script src="{% static 'ffmc.js' %}"></script>
-
+    <script>
+        // Set tomorrow's date when the button is clicked
+        document.getElementById('tomorrow-forecast').addEventListener('click', function() {
+            var tomorrow = new Date();
+            tomorrow.setDate(tomorrow.getDate() + 1);
+    
+            // Format the date in the format expected by the datepicker
+            var formattedDate = tomorrow.toISOString().split('T')[0];
+    
+            // Set the date in the datepicker
+            const date_input = document.querySelector('.datepicker-input');
+            date_input.value = formattedDate;
+    
+            // Trigger the change event to update the displayed date
+            var event = new Event('change');
+            date_input.dispatchEvent(event);
+        });
+    </script>
 </body>
-
 </html>

--- a/Site/bc_weather_station_dashboard/website/templates/weather.html
+++ b/Site/bc_weather_station_dashboard/website/templates/weather.html
@@ -43,7 +43,7 @@
             {% comment %} If you want to make map only take up 1/3 of page, use line below {% endcomment %}
             {% comment %} <div class="col-4 text-center border-right border-dark"> {% endcomment %}
             <div class="col-md-6 col-sm-12 text-center border-right">
-                <div class="foreground d-flex justify-content-between align-items-center mb-2" style="height: 65px;">
+                <div class="foreground d-flex justify-content-between align-items-center mb-3" style="height: 60px;">
                     <div class="align-self-center pt-2">
                         <h4 id="station-name-code" class="foreground"></h4>
                     </div>
@@ -77,8 +77,8 @@
             </div>
             <!-- Weather Data Column -->
             <div class="col-6 ">
-                <div class="foreground d-flex justify-content-between align-items-center" style="height: 65px;">
-                    <div class="align-self-center pl-3 pt-2">
+                <div class="foreground d-flex justify-content-between align-items-center" style="height: 60px;">
+                    <div class="align-self-center pl-3 pt-1">
                         <h3>Weather</h3>
                     </div>
                     <div>

--- a/Site/bc_weather_station_dashboard/website/tests/abi/map.test.js
+++ b/Site/bc_weather_station_dashboard/website/tests/abi/map.test.js
@@ -173,14 +173,14 @@ describe('getSelectedDate() Functionality', () => {
         document.getElementById('selected_date').innerHTML = "Today";
         const fixedDate = new Date('2024-03-19T12:00:00Z');
         jest.useFakeTimers().setSystemTime(fixedDate);
-        expect(getSelectedDate()).toBe('2024-03-19 12:00:00');
+        expect(getSelectedDate()).toBe('2024-03-19');
         jest.useRealTimers();
     });
     // Create a test for getting the datetime when date picker is set to a specific date
     test('Correctly returns the current date and time when date picker is set to a specific date.', () => {
         const specificDate = '2024-03-19';
         document.getElementById('selected_date').innerHTML = specificDate;
-        expect(getSelectedDate()).toBe(specificDate + ' 12:00:00');
+        expect(getSelectedDate()).toBe(specificDate);
     });
 });
 


### PR DESCRIPTION
The dashboard now stores the station and date in the local storage and when switching or refreshing the page the new page will be loaded with the stored values. This allows the dashboard to stay on the same station and date when switching from weather to fire and vice versa.

Closes #154 